### PR TITLE
Extract parsing and transformation logic into modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,6 +2007,49 @@
         "babel-types": "^6.22.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+              "dev": true
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-runtime": "^6.22.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",

--- a/src/javascript/components/LoadingView.jsx
+++ b/src/javascript/components/LoadingView.jsx
@@ -84,12 +84,10 @@ export default class LoadingView extends React.Component {
     fontParsed(fonts) {
         const fontStage = this.state.progress.fontStage();
         fontStage.stepsDone++;
-        if (this.state.progress.activeStage() === fontStage) {
-            this.setState({ //force rendering
-                fontMap: fonts.map,
-                fontIds: fonts.ids,
-            });
-        }
+        this.setState({ //force rendering
+            fontMap: fonts.map,
+            fontIds: fonts.ids,
+        });
         fontStage.steps = fonts.ids.size;
     }
 

--- a/src/javascript/components/LoadingView.jsx
+++ b/src/javascript/components/LoadingView.jsx
@@ -97,11 +97,11 @@ export default class LoadingView extends React.Component {
                 fontMap: this.state.fontMap,
             });
         }
+        fontStage.steps = this.state.fontIds.size;
     }
 
     componentWillMount() {
         const self = this;
-        const fontStage = this.state.progress.fontStage();
 
         pdfjs.getDocument({
             data: this.props.fileBuffer,
@@ -130,7 +130,6 @@ export default class LoadingView extends React.Component {
                                     self.fontParsed(fontId, font);
                                 });
                                 self.state.fontIds.add(fontId);
-                                fontStage.steps = self.state.fontIds.size;
                             }
 
                             const tx = pdfjs.Util.transform( // eslint-disable-line no-undef

--- a/src/javascript/components/ResultView.jsx
+++ b/src/javascript/components/ResultView.jsx
@@ -5,7 +5,7 @@ import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar'
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup'
 import Button from 'react-bootstrap/lib/Button'
 
-import ParseResult from '../models/ParseResult.jsx';
+import { transform } from '../lib/transformations.jsx'
 
 export default class ResultView extends React.Component {
 
@@ -20,17 +20,7 @@ export default class ResultView extends React.Component {
 
     componentWillMount() {
         const {pages, transformations} = this.props;
-        var parseResult = new ParseResult({
-            pages: pages
-        });
-        var lastTransformation;
-        transformations.forEach(transformation => {
-            if (lastTransformation) {
-                parseResult = lastTransformation.completeTransform(parseResult);
-            }
-            parseResult = transformation.transform(parseResult);
-            lastTransformation = transformation;
-        });
+        const parseResult = transform(pages, transformations);
 
         var text = '';
         parseResult.pages.forEach(page => {

--- a/src/javascript/lib/pdf.jsx
+++ b/src/javascript/lib/pdf.jsx
@@ -11,7 +11,7 @@ export async function parse(docOptions, callbacks) {
     pageParsed: NO_OP,
     fontParsed: NO_OP,
     documentParsed: NO_OP,
-    ...callbacks,
+    ...(callbacks || {}),
   }
   const pdfDocument = await pdfjs.getDocument(docOptions)
   const metadata = await pdfDocument.getMetadata()

--- a/src/javascript/lib/pdf.jsx
+++ b/src/javascript/lib/pdf.jsx
@@ -1,0 +1,77 @@
+import pdfjs from 'pdfjs-dist'
+
+import TextItem from '../models/TextItem.jsx'
+import Page from '../models/Page.jsx'
+
+const NO_OP = () => {}
+
+export async function parse(docOptions, callbacks) {
+  const { metadataParsed, pageParsed, fontParsed, documentParsed } = {
+    metadataParsed: NO_OP,
+    pageParsed: NO_OP,
+    fontParsed: NO_OP,
+    documentParsed: NO_OP,
+    ...callbacks,
+  }
+  const pdfDocument = await pdfjs.getDocument(docOptions)
+  const metadata = await pdfDocument.getMetadata()
+  metadataParsed(metadata)
+
+  const pages = [...Array(pdfDocument.numPages).keys()].map(
+    index => new Page({ index })
+  )
+
+  documentParsed(pdfDocument, pages)
+
+  const fonts = {
+    ids: new Set(),
+    map: new Map(),
+  }
+
+  for (let j = 1; j <= pdfDocument.numPages; j++) {
+    const page = await pdfDocument.getPage(j)
+    const scale = 1.0
+    const viewport = page.getViewport(scale)
+    const textContent = await page.getTextContent()
+    const textItems = textContent.items.map(item => {
+      const fontId = item.fontName
+
+      if (!fonts.ids.has(fontId) && fontId.startsWith('g_d0')) {
+        pdfDocument.transport.commonObjs.get(fontId, font => {
+          if (!fonts.ids.has(fontId)) {
+            fonts.ids.add(fontId)
+            fonts.map.set(fontId, font)
+            fontParsed(fonts)
+          }
+        })
+      }
+
+      const tx = pdfjs.Util.transform(
+        viewport.transform,
+        item.transform
+      )
+
+      const fontHeight = Math.sqrt((tx[2] * tx[2]) + (tx[3] * tx[3]));
+      const dividedHeight = item.height / fontHeight;
+      return new TextItem({
+          x: Math.round(item.transform[4]),
+          y: Math.round(item.transform[5]),
+          width: Math.round(item.width),
+          height: Math.round(dividedHeight <= 1 ? item.height : dividedHeight),
+          text: item.str,
+          font: fontId,
+      })
+    })
+    pages[page.pageIndex].items = textItems
+    pageParsed(pages)
+
+    // Trigger the font retrieval for the page
+    page.getOperatorList()
+  }
+  return {
+    fonts,
+    metadata,
+    pages,
+    pdfDocument,
+  }
+}

--- a/src/javascript/lib/transformations.jsx
+++ b/src/javascript/lib/transformations.jsx
@@ -1,0 +1,46 @@
+import CalculateGlobalStats from '../models/transformations/textitem/CalculateGlobalStats.jsx'
+
+import CompactLines from '../models/transformations/lineitem/CompactLines.jsx'
+import RemoveRepetitiveElements from '../models/transformations/lineitem/RemoveRepetitiveElements.jsx'
+import VerticalToHorizontal from '../models/transformations/lineitem/VerticalToHorizontal.jsx'
+import DetectTOC from '../models/transformations/lineitem/DetectTOC.jsx'
+import DetectListItems from '../models/transformations/lineitem/DetectListItems.jsx'
+import DetectHeaders from '../models/transformations/lineitem/DetectHeaders.jsx'
+
+import GatherBlocks from '../models/transformations/textitemblock/GatherBlocks.jsx'
+import DetectCodeQuoteBlocks from '../models/transformations/textitemblock/DetectCodeQuoteBlocks.jsx'
+import DetectListLevels from '../models/transformations/textitemblock/DetectListLevels.jsx'
+import ToTextBlocks from '../models/transformations/ToTextBlocks.jsx'
+import ToMarkdown from '../models/transformations/ToMarkdown.jsx'
+
+import ParseResult from '../models/ParseResult.jsx'
+
+export const makeTransformations = fontMap => [
+  new CalculateGlobalStats(fontMap),
+  new CompactLines(),
+  new RemoveRepetitiveElements(),
+  new VerticalToHorizontal(),
+  new DetectTOC(),
+  new DetectHeaders(),
+  new DetectListItems(),
+
+  new GatherBlocks(),
+  new DetectCodeQuoteBlocks(),
+  new DetectListLevels(),
+
+  new ToTextBlocks(),
+  new ToMarkdown(),
+]
+
+export const transform = (pages, transformations) => {
+  var parseResult = new ParseResult({ pages })
+  let lastTransformation
+  transformations.forEach(transformation => {
+      if (lastTransformation) {
+          parseResult = lastTransformation.completeTransform(parseResult)
+      }
+      parseResult = transformation.transform(parseResult)
+      lastTransformation = transformation
+  })
+  return parseResult
+}

--- a/src/javascript/models/AppState.jsx
+++ b/src/javascript/models/AppState.jsx
@@ -1,19 +1,5 @@
 import { Enum } from 'enumify';
-
-import CalculateGlobalStats from './transformations/textitem/CalculateGlobalStats.jsx';
-
-import CompactLines from './transformations/lineitem/CompactLines.jsx';
-import RemoveRepetitiveElements from './transformations/lineitem/RemoveRepetitiveElements.jsx'
-import VerticalToHorizontal from './transformations/lineitem/VerticalToHorizontal.jsx';
-import DetectTOC from './transformations/lineitem/DetectTOC.jsx'
-import DetectListItems from './transformations/lineitem/DetectListItems.jsx'
-import DetectHeaders from './transformations/lineitem/DetectHeaders.jsx'
-
-import GatherBlocks from './transformations/textitemblock/GatherBlocks.jsx'
-import DetectCodeQuoteBlocks from './transformations/textitemblock/DetectCodeQuoteBlocks.jsx'
-import DetectListLevels from './transformations/textitemblock/DetectListLevels.jsx'
-import ToTextBlocks from './transformations/ToTextBlocks.jsx';
-import ToMarkdown from './transformations/ToMarkdown.jsx'
+import { makeTransformations } from '../lib/transformations.jsx';
 
 // Holds the state of the Application
 export default class AppState {
@@ -50,21 +36,7 @@ export default class AppState {
         this.fileBuffer = null;
         this.mainView = View.RESULT;
 
-        this.transformations = [
-            new CalculateGlobalStats(fontMap),
-            new CompactLines(),
-            new RemoveRepetitiveElements(),
-            new VerticalToHorizontal(),
-            new DetectTOC(),
-            new DetectHeaders(),
-            new DetectListItems(),
-
-            new GatherBlocks(),
-            new DetectCodeQuoteBlocks(),
-            new DetectListLevels(),
-
-            new ToTextBlocks(),
-            new ToMarkdown()];
+        this.transformations = makeTransformations(fontMap);
 
         this.render();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
         ]
     },
     entry: {
-        app: './javascript/index.jsx'
+        app: ['babel-polyfill', './javascript/index.jsx']
     },
     output: {
         path: BUILD_DIR,


### PR DESCRIPTION
- Let `fontParsed()` handle progress tracking
- Extract PDF parser from LoadingView into `lib/pdf`
- Allow callbacks to be invoked from the parser; use this to track
  progress in the Web UI
- LoadingView: Ensure font map kept updated regardless of parsing stage
- Create `lib/transformations` and move the transformation pipeline
defined in AppState to it, along with the logic in ResultsView that
executes the transformation pipeline into a function

Support work for #3