### PR TITLE
Create a CLI tool

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,14 +2,32 @@
   "env": {
     "testing": {
       "presets": ["@babel/preset-env"]
-    }
-  },
-  "presets": [ 
-    [ "@babel/preset-env", { "loose": false, "modules": false, "targets": "> 0.25%, not dead" } ], 
-    "@babel/preset-react", 
-    "@babel/preset-flow"
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-class-properties"
-  ]
+    },
+    "browser": {
+      "plugins": [
+        "@babel/plugin-proposal-class-properties"
+      ],
+      "presets": [
+        [ "@babel/preset-env", { "loose": false, "modules": false, "targets": "> 0.25%, not dead"} ], 
+        "@babel/preset-react",
+        "@babel/preset-flow"
+      ],
+    },
+    "cli": {
+      "ignore": [
+        "src/javascript/pdf2md.js",
+        "src/javascript/pdf2md-cli.js",
+        "src/javascript/index.jsx"
+      ],
+      "plugins": [
+        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-transform-modules-commonjs"
+      ],
+      "presets": [
+        [ "@babel/preset-env", { "loose": false, "modules": false, "targets": {"node": true}} ],
+        "@babel/preset-react",
+        "@babel/preset-flow"
+      ],
+    } 
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 build/
 npm-debug.log
 .eslintcache
+dist/
+output/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,25 @@ Use the [issue tracker](https://github.com/jzillmann/pdf-to-markdown/issues) and
 - ```npm run watch``` Continuously build the project
 - ```open build/index.html``` Open the build project in your default browser
 - ```npm run release``` Build production version
-- ```npm run deploy``` Build production version & move it to the github pages fodler
+- ```npm run deploy``` Build production version & move it to the github pages foldler
+- ```npm run prepare``` Babelify necessary files and package into the `dist/` directory
+
+#### CLI tool
+Instructions to run:
+<pre>
+$ cd [project_folder]
+$ npm run prepare
+$ node dist/pdf2md-cli.js --inputFolderPath=[your input folder path] --outputFolderPath=[your output folder path] --recursive=[true or false]
+</pre>
+If you are converting recursively on a large number of files you might encounter the error "Allocation failed - JavaScript heap out of memory”. Instead, run the command
+<pre>
+$ node --max-old-space-size=4096 index.js --inputFolderPath=[your input folder path] --outputFolderPath=[your output folder path] --recursive=[1 or 0]
+</pre>
+
+Options:
+1. Input folder path (should exist)
+2. Output folder path (should exist)
+3. Recursive - convert all PDFs for folders within folders
 
 #### Release
 - Increase version in package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,79 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.4.4.tgz",
+      "integrity": "sha512-XGr5YjQSjgTa6OzQZY57FAJsdeVSAKR/u/KA5exWIz66IKtv/zXtHy+fIZcMry/EgYegwuHE7vzGnrFhjdIAsQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.4",
+        "commander": "^2.8.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.11",
+        "mkdirp": "^0.5.1",
+        "output-file-sync": "^2.0.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+          "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true,
+          "optional": true
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "upath": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+          "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -1629,9 +1702,9 @@
       }
     },
     "babel-messages": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz",
-      "integrity": "sha1-NgZqIU8SF+TtQWSGdmnss54+pXU=",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -1659,20 +1732,85 @@
       }
     },
     "babel-traverse": {
-      "version": "6.22.1",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
-      "integrity": "sha1-O5XNa3Qn1vH3V3BJCPL8l0il9Z8=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-messages": "^6.22.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.22.0",
-        "babylon": "^6.15.0",
-        "debug": "^2.2.0",
-        "globals": "^9.0.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
       }
     },
     "babel-types": {
@@ -1862,13 +2000,21 @@
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.1",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        }
       }
     },
     "braces": {
@@ -2196,23 +2342,31 @@
       }
     },
     "chokidar": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.1.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.0"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
       }
     },
     "cipher-base": {
@@ -2911,12 +3065,12 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
-        "ms": "0.7.2"
+        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -4228,6 +4382,12 @@
         "path-is-absolute": "^1.0.0",
         "rimraf": "^2.2.8"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6051,9 +6211,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -6484,9 +6644,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mixin-deep": {
@@ -6517,6 +6677,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -6579,9 +6747,9 @@
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multicast-dns": {
@@ -7024,6 +7192,17 @@
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
+      }
+    },
+    "output-file-sync": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
+      "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "is-plain-obj": "^1.1.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "p-finally": {
@@ -8084,15 +8263,14 @@
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "readline2": {
@@ -8591,12 +8769,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -8685,6 +8857,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
     "slice-ansi": {
@@ -9639,9 +9817,9 @@
       }
     },
     "upath": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
     "upper-case": {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "pdf-to-markdown",
   "version": "0.1.1",
   "description": "A PDF to Markdown Converter",
-  "main": "main.js",
+  "main": "src/javascript/pdf2md.js",
   "scripts": {
     "watch": "webpack -d --watch",
-    "build": "webpack",
+    "build": "NODE_ENV=browser webpack",
     "start": "webpack-dev-server",
     "lint": "eslint src --ext .js --ext .jsx --cache",
     "test": "NODE_ENV=testing mocha --compilers js:@babel/register test --recursive",
     "check": "npm run lint && npm run test",
     "release": "npm run lint && rm -rf build/* && NODE_ENV=production webpack -p",
-    "deploy": "npm run release && cp -r build/* docs/"
+    "deploy": "npm run release && cp -r build/* docs/",
+    "prepare": "NODE_ENV=cli babel src/javascript --copy-files --out-dir dist/ --keep-file-extension"
   },
   "keywords": [
     "PDF",
@@ -39,6 +40,7 @@
     "remarkable": "^1.7.1"
   },
   "devDependencies": {
+    "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
@@ -58,6 +60,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^0.10.0",
     "html-webpack-plugin": "^2.22.0",
+    "minimist": "^1.2.0",
     "mocha": "^3.2.0",
     "regenerator-runtime": "^0.13.2",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "pdf-to-markdown",
+  "name": "@opendocsg/pdf2md",
   "version": "0.1.1",
   "description": "A PDF to Markdown Converter",
-  "main": "src/javascript/pdf2md.js",
+  "main": "dist/pdf2md.js",
+  "bin": {
+    "pdf2md": "dist/pdf2md-cli.js"
+  },
   "scripts": {
     "watch": "webpack -d --watch",
     "build": "NODE_ENV=browser webpack",
-    "start": "webpack-dev-server",
+    "start": "NODE_ENV=browser webpack-dev-server",
     "lint": "eslint src --ext .js --ext .jsx --cache",
     "test": "NODE_ENV=testing mocha --compilers js:@babel/register test --recursive",
     "check": "npm run lint && npm run test",

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -60,7 +60,7 @@ function getPaths(folderPath) {
       if (isDirectory) {
           folderPaths.push(folderPath + '/' + directoryItem)
       } 
-      if (directoryItem.split('.').pop() == 'pdf') {
+      if (directoryItem.split('.').pop() === 'pdf') {
           filePaths.push(folderPath + '/' + directoryItem)
       }
   });

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/* eslint no-console: 0 */
+
+const pdf2md = require('./pdf2md')
+
+const fs = require('fs')
+const path = require('path')
+
+const [ appName, inputFile, outputPath ] = process.argv
+
+if (!inputFile) {
+  console.log(`Usage: ${appName} ${inputFile} [${outputPath}]`)
+  process.exit(1)
+}
+
+// If outputPath specified, supply callbacks to log progress
+const callbacks = outputPath && {}
+
+const pdfBuffer = fs.readFileSync(path.resolve(inputFile))
+pdf2md(pdfBuffer, callbacks)
+  .then(text => {
+    if (outputPath) {
+      console.log(`Writing to ${outputPath}...`)
+      fs.writeFileSync(path.resolve(outputPath), text)
+      console.log('Done.')
+    } else {
+      console.log(text)
+    }
+  })
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -7,7 +7,7 @@ const pdf2md = require('./pdf2md')
 const fs = require('fs')
 const path = require('path')
 
-const [ appName, inputFile, outputPath ] = process.argv
+const [ node, appName, inputFile, outputPath ] = process.argv
 
 if (!inputFile) {
   console.log(`Usage: ${appName} ${inputFile} [${outputPath}]`)
@@ -21,8 +21,9 @@ const pdfBuffer = fs.readFileSync(path.resolve(inputFile))
 pdf2md(pdfBuffer, callbacks)
   .then(text => {
     if (outputPath) {
-      console.log(`Writing to ${outputPath}...`)
-      fs.writeFileSync(path.resolve(outputPath), text)
+      const outputFile = outputPath + "/output.md"
+      console.log(`Writing to ${outputFile}...`)
+      fs.writeFileSync(path.resolve(outputFile), text)
       console.log('Done.')
     } else {
       console.log(text)

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -4,32 +4,84 @@
 
 const pdf2md = require('./pdf2md')
 
-const fs = require('fs')
+
+const fs = require('fs');
 const path = require('path')
+var argv = require('minimist')(process.argv.slice(2));
 
-const [ node, appName, inputFile, outputPath ] = process.argv
-
-if (!inputFile) {
-  console.log(`Usage: ${appName} ${inputFile} [${outputPath}]`)
-  process.exit(1)
+if (!argv["inputFolderPath"]) {
+    console.log("Please specify inputFolderPath")
+} else if (!argv["outputFolderPath"]) {
+    console.log("Please specify outputFolderPath")
+} else if (!argv["recursive"]) {
+    console.log("Please specify recursive equals 1 or 0")
+} else {
+    const folderPath = argv["inputFolderPath"]
+    const outputPath = argv["outputFolderPath"] 
+    const recursive = parseInt(argv["recursive"])
+    run(folderPath, outputPath, recursive)
 }
 
-// If outputPath specified, supply callbacks to log progress
-const callbacks = outputPath && {}
+function run(folderPath, outputPath, recursive=1) {
+  var outputArray = getPaths(folderPath)
+  var filePaths = outputArray[0]
+  var folderPaths = outputArray[1]
+  var allFolderPaths = folderPaths
+  if (recursive) {
+      while (allFolderPaths.length != 0) {
+          var nextFolderPaths = []
+          allFolderPaths.forEach(folderPath => {
+              outputArray = getPaths(folderPath)
+              filePaths = filePaths.concat(outputArray[0])
+              nextFolderPaths = nextFolderPaths.concat(outputArray[1])
+              folderPaths = folderPaths.concat(outputArray[1])
+          });
+          allFolderPaths = nextFolderPaths
+      }
+  }
+  var allOutputPaths = filePaths.map(x => {
+      return outputPath + x.split(folderPath)[1].split('.')[0]
+  })
+  allOutputPaths.forEach(outputPath => {
+      outputPath = outputPath.split('/').slice(0, -1).join('/')
+      if (!fs.existsSync(outputPath)) {
+          fs.mkdirSync(outputPath, { recursive: true })
+      }
+  })
+  createMarkdownFiles(filePaths, allOutputPaths)
+}
 
-const pdfBuffer = fs.readFileSync(path.resolve(inputFile))
-pdf2md(pdfBuffer, callbacks)
-  .then(text => {
-    if (outputPath) {
-      const outputFile = outputPath + "/output.md"
-      console.log(`Writing to ${outputFile}...`)
-      fs.writeFileSync(path.resolve(outputFile), text)
-      console.log('Done.')
-    } else {
-      console.log(text)
-    }
+function getPaths(folderPath) {
+  var filePaths = []
+  var folderPaths = []
+  var directoryItems = fs.readdirSync(folderPath)
+  directoryItems.forEach(directoryItem => {
+      const isDirectory = fs.lstatSync(folderPath + '/' + directoryItem).isDirectory()
+      if (isDirectory) {
+          folderPaths.push(folderPath + '/' + directoryItem)
+      } 
+      if (directoryItem.split('.').pop() == 'pdf') {
+          filePaths.push(folderPath + '/' + directoryItem)
+      }
+  });
+  return [filePaths, folderPaths]
+}
+
+function createMarkdownFiles(filePaths, allOutputPaths) {
+  // If outputPath specified, supply callbacks to log progress
+  filePaths.forEach(async function(filePath, i) {
+      const callbacks = allOutputPaths[i] && {}
+      const pdfBuffer = fs.readFileSync(filePath)
+      pdf2md(pdfBuffer, callbacks)
+        .then(text => {
+          let outputFile = allOutputPaths[i] + '.md'
+          console.log(`Writing to ${outputFile}...`)
+          fs.writeFileSync(path.resolve(outputFile), text)
+          console.log('Done.')
+        })
+        .catch(err => {
+          console.error(err)
+          process.exit(1)
+        })
   })
-  .catch(err => {
-    console.error(err)
-    process.exit(1)
-  })
+}

--- a/src/javascript/pdf2md.js
+++ b/src/javascript/pdf2md.js
@@ -16,15 +16,13 @@ const { makeTransformations, transform } = require('./lib/transformations.jsx')
  * 
  * @returns {string} The Markdown text
  */
-export default async function pdf2md (pdfBuffer, callbacks) {
+module.exports = async function(pdfBuffer, callbacks) {
   const result = await parse(pdfBuffer, callbacks)
-  
   const { fonts, pages } = result
   const transformations = makeTransformations(fonts.map)
   const parseResult = transform(pages, transformations)
   const text = parseResult.pages
     .map(page => page.items.join('\n') + '\n')
     .join('')
-
   return text
 }

--- a/src/javascript/pdf2md.js
+++ b/src/javascript/pdf2md.js
@@ -1,0 +1,30 @@
+const { parse } = require('./lib/pdf.jsx')
+const { makeTransformations, transform } = require('./lib/transformations.jsx')
+
+/**
+ * Reads a 
+ * @param {string|TypedArray|DocumentInitParameters|PDFDataRangeTransport} pdfBuffer
+ * Passed to `pdfjs.getDocument()` to read a PDF document for conversion
+ * 
+ * @param {Object} [callbacks]
+ * Optional. A collection of callbacks to invoke when  
+ * elements within the PDF document are parsed
+ * @param {Function} [callbacks.metadataParsed]
+ * @param {Function} [callbacks.pageParsed]
+ * @param {Function} [callbacks.fontParsed]
+ * @param {Function} [callbacks.documentParsed]
+ * 
+ * @returns {string} The Markdown text
+ */
+export default async function pdf2md (pdfBuffer, callbacks) {
+  const result = await parse(pdfBuffer, callbacks)
+  
+  const { fonts, pages } = result
+  const transformations = makeTransformations(fonts.map)
+  const parseResult = transform(pages, transformations)
+  const text = parseResult.pages
+    .map(page => page.items.join('\n') + '\n')
+    .join('')
+
+  return text
+}


### PR DESCRIPTION
[modules]
- Create `pdf2md`, which hooks the PDF parser and transformation logic
  into a single convenience function and exports it
- Create `pdf2md-cli`, which imports pdf2md and uses it to
  parse a PDF whose path is supplied at the command line, outputting
  either to stdout or a specified output file

[npm]
- Bablify above modules along with React dependencies into `dist/` 
  in `npm prepare`
- Make `pdf2md` the main entry point for this package, and include 
  a bin that invokes `pdf2md-cli`
- Publish as @opendocsg/pdf2md

[misc]
- Update the README to reflect changes

Fixes #3