### PR TITLE
Babel: Ensure production profile present

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,16 @@
         "@babel/preset-flow"
       ],
     },
+    "production": {
+      "plugins": [
+        "@babel/plugin-proposal-class-properties"
+      ],
+      "presets": [
+        [ "@babel/preset-env", { "loose": false, "modules": false, "targets": "> 0.25%, not dead"} ], 
+        "@babel/preset-react",
+        "@babel/preset-flow"
+      ],
+    },
     "cli": {
       "ignore": [
         "src/javascript/pdf2md.js",


### PR DESCRIPTION
Duplicate the browser profile for production so that `npm run release`
works properly