### PR TITLE
Continue processing non-error files

### DIFF
--- a/src/javascript/models/markdown/BlockType.jsx
+++ b/src/javascript/models/markdown/BlockType.jsx
@@ -110,7 +110,7 @@ export function headlineByLevel(level) {
         return BlockType.H6;
     } else {
         // if level is >= 6, just use BlockType H6
-        console.warn('Unsupported headline level: " + level + " (supported are 1-6), defaulting to level 6');
+        console.warn("Unsupported headline level: " + level + " (supported are 1-6), defaulting to level 6");
         return BlockType.H6;
     }
 }

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -46,7 +46,6 @@ function run(folderPath, outputPath, recursive=1) {
           fs.mkdirSync(outputPath, { recursive: true })
       }
   })
-  console.log(allOutputPaths)
   createMarkdownFiles(filePaths, allOutputPaths)
 }
 

--- a/src/javascript/pdf2md-cli.js
+++ b/src/javascript/pdf2md-cli.js
@@ -46,6 +46,7 @@ function run(folderPath, outputPath, recursive=1) {
           fs.mkdirSync(outputPath, { recursive: true })
       }
   })
+  console.log(allOutputPaths)
   createMarkdownFiles(filePaths, allOutputPaths)
 }
 
@@ -67,7 +68,7 @@ function getPaths(folderPath) {
 
 function createMarkdownFiles(filePaths, allOutputPaths) {
   // If outputPath specified, supply callbacks to log progress
-  filePaths.forEach(async function(filePath, i) {
+  filePaths.forEach(function(filePath, i) {
       const callbacks = allOutputPaths[i] && {}
       const pdfBuffer = fs.readFileSync(filePath)
       pdf2md(pdfBuffer, callbacks)
@@ -79,7 +80,6 @@ function createMarkdownFiles(filePaths, allOutputPaths) {
         })
         .catch(err => {
           console.error(err)
-          process.exit(1)
         })
   })
 }


### PR DESCRIPTION
    - Remove process.exit(1) so that an error will not disrupt
    processing of other PDF files #17 