### PR TITLE
Decouple UI concerns from `models/transformations`

### DIFF
--- a/src/javascript/components/DebugView.jsx
+++ b/src/javascript/components/DebugView.jsx
@@ -14,6 +14,8 @@ import AutoAffix from 'react-overlays/lib/AutoAffix';
 
 import ParseResult from '../models/ParseResult.jsx';
 
+import { transformationToPageView } from './debug/index.jsx'
+
 // A view which displays the content of the given pages transformed by the given transformations
 export default class DebugView extends React.Component {
 
@@ -89,7 +91,7 @@ export default class DebugView extends React.Component {
         }
 
         parseResult.pages = parseResult.pages.filter((elem, i) => pageNr == -1 || i == pageNr);
-        const pageComponents = parseResult.pages.map(page => lastTransformation.createPageView(page, this.state.modificationsOnly));
+        const pageComponents = parseResult.pages.map(page => transformationToPageView[lastTransformation.constructor.name](page, this.state.modificationsOnly));
         const showModificationCheckbox = lastTransformation.showModificationCheckbox();
         const statisticsAsList = Object.keys(parseResult.globals).map((key, i) => {
             return <li key={ i }>

--- a/src/javascript/components/DebugView.jsx
+++ b/src/javascript/components/DebugView.jsx
@@ -14,7 +14,9 @@ import AutoAffix from 'react-overlays/lib/AutoAffix';
 
 import ParseResult from '../models/ParseResult.jsx';
 
-import { transformationToPageView } from './debug/index.jsx'
+import { transformationToPageView, showModificationCheckbox } from './debug/index.jsx'
+
+const showCheckbox = showModificationCheckbox
 
 // A view which displays the content of the given pages transformed by the given transformations
 export default class DebugView extends React.Component {
@@ -92,7 +94,7 @@ export default class DebugView extends React.Component {
 
         parseResult.pages = parseResult.pages.filter((elem, i) => pageNr == -1 || i == pageNr);
         const pageComponents = parseResult.pages.map(page => transformationToPageView[lastTransformation.constructor.name](page, this.state.modificationsOnly));
-        const showModificationCheckbox = lastTransformation.showModificationCheckbox();
+        const showModificationCheckbox = showCheckbox(lastTransformation.constructor.name);
         const statisticsAsList = Object.keys(parseResult.globals).map((key, i) => {
             return <li key={ i }>
                      { key + ': ' + JSON.stringify(parseResult.globals[key]) }

--- a/src/javascript/components/debug/index.jsx
+++ b/src/javascript/components/debug/index.jsx
@@ -22,6 +22,7 @@ import ToMarkdown from '../../models/transformations/ToMarkdown.jsx'
 import TextPageView from './TextPageView.jsx'
 import ToTextBlocks from '../../models/transformations/ToTextBlocks.jsx'
 
+export const showModificationCheckbox = name => name !== ToMarkdown.name && name !== ToTextBlocks.name
 export const transformationToPageView = {}
 
 function textItem (page, modificationsOnly) {

--- a/src/javascript/components/debug/index.jsx
+++ b/src/javascript/components/debug/index.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+
+import TextItemPageView from './TextItemPageView.jsx'
+import CalculateGlobalStats from '../../models/transformations/textitem/CalculateGlobalStats.jsx'
+
+import LineItemPageView from './LineItemPageView.jsx'
+import CompactLines from '../../models/transformations/lineitem/CompactLines.jsx'
+import RemoveRepetitiveElements from '../../models/transformations/lineitem/RemoveRepetitiveElements.jsx'
+import VerticalToHorizontal from '../../models/transformations/lineitem/VerticalToHorizontal.jsx'
+import DetectTOC from '../../models/transformations/lineitem/DetectTOC.jsx'
+import DetectListItems from '../../models/transformations/lineitem/DetectListItems.jsx'
+import DetectHeaders from '../../models/transformations/lineitem/DetectHeaders.jsx'
+
+import LineItemBlockPageView from './LineItemBlockPageView.jsx'
+import GatherBlocks from '../../models/transformations/textitemblock/GatherBlocks.jsx'
+import DetectCodeQuoteBlocks from '../../models/transformations/textitemblock/DetectCodeQuoteBlocks.jsx'
+import DetectListLevels from '../../models/transformations/textitemblock/DetectListLevels.jsx'
+
+import MarkdownPageView from './MarkdownPageView.jsx'
+import ToMarkdown from '../../models/transformations/ToMarkdown.jsx'
+
+import TextPageView from './TextPageView.jsx'
+import ToTextBlocks from '../../models/transformations/ToTextBlocks.jsx'
+
+export const transformationToPageView = {}
+
+function textItem (page, modificationsOnly) {
+  return <TextItemPageView
+    key={ page.index }
+    page={ page }
+    modificationsOnly={ modificationsOnly }
+    showWhitespaces={ false } />
+}
+
+transformationToPageView[CalculateGlobalStats.name] = textItem
+
+function lineItem (page, modificationsOnly) {
+  return <LineItemPageView
+    key={ page.index }
+    page={ page }
+    modificationsOnly={ modificationsOnly }
+    showWhitespaces={ false } />
+}
+
+transformationToPageView[CompactLines.name] = lineItem
+transformationToPageView[RemoveRepetitiveElements.name] = lineItem
+transformationToPageView[VerticalToHorizontal.name] = lineItem
+transformationToPageView[DetectTOC.name] = lineItem
+transformationToPageView[DetectListItems.name] = lineItem
+transformationToPageView[DetectHeaders.name] = lineItem
+
+
+function lineItemBlock (page, modificationsOnly) {
+  return <LineItemBlockPageView
+    key={ page.index }
+    page={ page }
+    modificationsOnly={ modificationsOnly }
+    showWhitespaces={ false } />
+}
+
+transformationToPageView[GatherBlocks.name] = lineItemBlock
+transformationToPageView[DetectCodeQuoteBlocks.name] = lineItemBlock
+
+transformationToPageView[DetectListLevels.name] = function lineItemBlockWithSpaces (page, modificationsOnly) {
+  return <LineItemBlockPageView
+    key={ page.index }
+    page={ page }
+    modificationsOnly={ modificationsOnly }
+    showWhitespaces={ true } />
+}
+
+transformationToPageView[ToMarkdown.name] = function markdown (page) {
+  return <MarkdownPageView key={ page.index } page={ page } />
+}
+
+transformationToPageView[ToTextBlocks.name] = function text (page) {
+  return <TextPageView key={ page.index } page={ page } />
+}
+

--- a/src/javascript/models/transformations/ToLineItemBlockTransformation.jsx
+++ b/src/javascript/models/transformations/ToLineItemBlockTransformation.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
 import Transformation from './Transformation.jsx';
 import ParseResult from '../ParseResult.jsx';
 import LineItemBlock from '../LineItemBlock.jsx';
-import LineItemBlockPageView from '../../components/debug/LineItemBlockPageView.jsx';
 import { REMOVED_ANNOTATION } from '../Annotation.jsx';
 
 // Abstract class for transformations producing LineItemBlock(s) to be shown in the LineItemBlockPageView
@@ -13,19 +11,6 @@ export default class ToLineItemBlockTransformation extends Transformation {
         if (this.constructor === ToLineItemBlockTransformation) {
             throw new TypeError("Can not construct abstract class.");
         }
-        this.showWhitespaces = false;
-    }
-
-    showModificationCheckbox() {
-        return true;
-    }
-
-    createPageView(page, modificationsOnly) {
-        return <LineItemBlockPageView
-                                      key={ page.index }
-                                      page={ page }
-                                      modificationsOnly={ modificationsOnly }
-                                      showWhitespaces={ this.showWhitespaces } />;
     }
 
     completeTransform(parseResult:ParseResult) {

--- a/src/javascript/models/transformations/ToLineItemTransformation.jsx
+++ b/src/javascript/models/transformations/ToLineItemTransformation.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
 import Transformation from './Transformation.jsx';
 import ParseResult from '../ParseResult.jsx';
 import LineItem from '../LineItem.jsx';
-import LineItemPageView from '../../components/debug/LineItemPageView.jsx';
 import { REMOVED_ANNOTATION } from '../Annotation.jsx';
 
 // Abstract class for transformations producing LineItem(s) to be shown in the LineItemPageView
@@ -13,19 +11,6 @@ export default class ToLineItemTransformation extends Transformation {
         if (this.constructor === ToLineItemTransformation) {
             throw new TypeError("Can not construct abstract class.");
         }
-        this.showWhitespaces = false;
-    }
-
-    showModificationCheckbox() {
-        return true;
-    }
-
-    createPageView(page, modificationsOnly) {
-        return <LineItemPageView
-                                 key={ page.index }
-                                 page={ page }
-                                 modificationsOnly={ modificationsOnly }
-                                 showWhitespaces={ this.showWhitespaces } />;
     }
 
     completeTransform(parseResult:ParseResult) {

--- a/src/javascript/models/transformations/ToMarkdown.jsx
+++ b/src/javascript/models/transformations/ToMarkdown.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import MarkdownPageView from '../../components/debug/MarkdownPageView.jsx';
 import Transformation from './Transformation.jsx';
 import ParseResult from '../ParseResult.jsx';
 
@@ -7,10 +5,6 @@ export default class ToMarkdown extends Transformation {
 
     constructor() {
         super("To Markdown", "String");
-    }
-
-    createPageView(page, modificationsOnly) { // eslint-disable-line no-unused-vars
-        return <MarkdownPageView key={ page.index } page={ page } />;
     }
 
     transform(parseResult:ParseResult) {

--- a/src/javascript/models/transformations/ToTextBlocks.jsx
+++ b/src/javascript/models/transformations/ToTextBlocks.jsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import Transformation from './Transformation.jsx';
-import TextPageView from '../../components/debug/TextPageView.jsx';
 import ParseResult from '../ParseResult.jsx';
 import { blockToText } from '../markdown/BlockType.jsx';
 
@@ -8,10 +6,6 @@ export default class ToTextBlocks extends Transformation {
 
     constructor() {
         super("To Text Blocks", "TextBlock");
-    }
-
-    createPageView(page, modificationsOnly) { // eslint-disable-line no-unused-vars
-        return <TextPageView key={ page.index } page={ page } />;
     }
 
     transform(parseResult:ParseResult) {

--- a/src/javascript/models/transformations/ToTextItemTransformation.jsx
+++ b/src/javascript/models/transformations/ToTextItemTransformation.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
 import Transformation from './Transformation.jsx';
 import ParseResult from '../ParseResult.jsx';
 import TextItem from '../TextItem.jsx';
-import TextItemPageView from '../../components/debug/TextItemPageView.jsx';
 import { REMOVED_ANNOTATION } from '../Annotation.jsx';
 
 // Abstract class for transformations producing TextItem(s) to be shown in the TextItemPageView
@@ -13,19 +11,6 @@ export default class ToTextItemTransformation extends Transformation {
         if (this.constructor === ToTextItemTransformation) {
             throw new TypeError("Can not construct abstract class.");
         }
-        this.showWhitespaces = false;
-    }
-
-    showModificationCheckbox() {
-        return true;
-    }
-
-    createPageView(page, modificationsOnly) {
-        return <TextItemPageView
-                                 key={ page.index }
-                                 page={ page }
-                                 modificationsOnly={ modificationsOnly }
-                                 showWhitespaces={ this.showWhitespaces } />;
     }
 
     completeTransform(parseResult:ParseResult) {

--- a/src/javascript/models/transformations/Transformation.jsx
+++ b/src/javascript/models/transformations/Transformation.jsx
@@ -14,14 +14,6 @@ export default class Transformation {
         this.itemType = itemType;
     }
 
-    showModificationCheckbox() {
-        return false;
-    }
-
-    createPageView(page, modificationsOnly) { // eslint-disable-line no-unused-vars
-        throw new TypeError("Do not call abstract method foo from child.");
-    }
-
     // Transform an incoming ParseResult into an outgoing ParseResult
     transform(parseResult: ParseResult) { // eslint-disable-line no-unused-vars
         throw new TypeError("Do not call abstract method foo from child.");

--- a/src/javascript/models/transformations/textitemblock/DetectListLevels.jsx
+++ b/src/javascript/models/transformations/textitemblock/DetectListLevels.jsx
@@ -9,7 +9,6 @@ export default class DetectListLevels extends ToLineItemBlockTransformation {
 
     constructor() {
         super("Level Lists");
-        this.showWhitespaces = true;
     }
 
     transform(parseResult:ParseResult) {


### PR DESCRIPTION
Transformation models should not be concerned about UI concerns,
so decouple them from the React components found in debug

- Create `debug/index.jsx`, exporting a map keying transform names
  to an appropriate React component

- Port `createPageView()` impls from ToXXXTransformation models into
  the newly-created map

- Get DebugView to lookup transformations with `debug/index.jsx`

- Ensure DetectListLevels is rendered with whitespace

- Move `showModificationCheckbox()` to `debug/index.jsx`

- Remove UI-related logic from `models/transformations/*`