### PR TITLE
CompactLines: Refrain from generating JSX links

### DIFF
--- a/lib/models/LineConverter.jsx
+++ b/lib/models/LineConverter.jsx
@@ -8,6 +8,11 @@ import { ParsedElements } from './PageItem.jsx';
 import { isNumber, isListItemCharacter } from '../util/string-functions.jsx'
 import { sortByX } from '../util/page-item-functions.jsx'
 
+/*::
+import TextItem from './TextItem.jsx'
+import LineItem from './LineItem.jsx'
+*/
+
 // Converts text items which have been grouped to a line (through TextItemLineGrouper) to a single LineItem doing inline transformations like
 //'whitespace removal', bold/emphasis annotation, link-detection, etc..
 export default class LineConverter {
@@ -17,7 +22,7 @@ export default class LineConverter {
     }
 
     // returns a CombineResult
-    compact(textItems /*: TextItem[] */) {
+    compact(textItems /*: TextItem[] */) /*: LineItem */ {
         // we can't trust order of occurence, esp. footnoteLinks like to come last
         sortByX(textItems);
 

--- a/lib/models/transformations/line-item/CompactLines.jsx
+++ b/lib/models/transformations/line-item/CompactLines.jsx
@@ -1,7 +1,5 @@
 // @flow
 
-import React from 'react';
-
 import ToLineItemTransformation from '../ToLineItemTransformation.jsx';
 import ParseResult from '../../ParseResult.jsx';
 import LineItem from '../../LineItem.jsx';
@@ -60,12 +58,12 @@ export default class CompactLines extends ToLineItemTransformation {
                         linkCount++;
                     }
                     if (lineItem.parsedElements.footnoteLinks.length > 0) {
-                        const footnoteLinks = lineItem.parsedElements.footnoteLinks.map(footnoteLink => <span key={ footnoteLink }><a href={ "#Page " + (page.index + 1) }>{ footnoteLink }</a>,</span>);
+                        const footnoteLinks = lineItem.parsedElements.footnoteLinks.map(footnoteLink => ({ footnoteLink, page: page.index + 1 }));
                         foundFootnoteLinks.push.apply(foundFootnoteLinks, footnoteLinks);
                     }
                     if (lineItem.parsedElements.footnotes.length > 0) {
                         lineItem.type = BlockType.FOOTNOTES;
-                        const footnotes = lineItem.parsedElements.footnotes.map(footnote => <span key={ footnote }><a href={ "#Page " + (page.index + 1) }>{ footnote }</a>,</span>);
+                        const footnotes = lineItem.parsedElements.footnotes.map(footnote => ({ footnote, page: page.index + 1 }));
                         foundFootnotes.push.apply(foundFootnotes, footnotes);
                     }
                 });
@@ -79,8 +77,8 @@ export default class CompactLines extends ToLineItemTransformation {
             messages: [
                 'Detected ' + formattedWords + ' formatted words',
                 'Found ' + linkCount + ' links',
-                <span>Detected { foundFootnoteLinks.length } footnotes links: [{ foundFootnoteLinks }]</span>,
-                <span>Detected { foundFootnotes.length } footnotes: [{ foundFootnotes }]</span>,
+                'Detected ' +  foundFootnoteLinks.length + ' footnotes links',
+                'Detected ' +  foundFootnotes.length + ' footnotes',
             ]
         });
     }


### PR DESCRIPTION
The transformation steps embed messages in ParseResult mostly for use
in DebugView, where they are displayed to the user. CompactLines puts
in JSX elements, which require React. This has to be removed so that
`lib/` can be made into pure JS.

Knock out the aforementioned logic, limiting CompactLines' messages to
reporting how many footnotes are generated, not links that jump to the
page containing the footnotes.

Correct flow annotation for LineConverter whilst we are here